### PR TITLE
Make sure to get user's location

### DIFF
--- a/src/GeoClue.vala
+++ b/src/GeoClue.vala
@@ -23,7 +23,7 @@ public class Atlas.GeoClue : Object {
     public GeoClue () {
     }
 
-    public async GClue.Location? get_location () {
+    public async GClue.Location? get_current_location () {
         if (simple == null) {
             try {
                 simple = yield new GClue.Simple (Build.PROJECT_NAME, GClue.AccuracyLevel.EXACT, null);

--- a/src/GeoClue.vala
+++ b/src/GeoClue.vala
@@ -17,38 +17,22 @@
 * Inspired from https://gitlab.gnome.org/GNOME/gnome-clocks/blob/master/src/geocoding.vala
 */
 
-public class Atlas.GeoClue {
-
-    public signal void location_changed (GClue.Location loc);
-
-    private const string DESKTOP_ID = Build.PROJECT_NAME;
-
-    private GClue.Simple simple;
-    private string country_code;
-    private double minimal_distance;
-    public GClue.Location? geo_location { get; private set; default = null; }
+public class Atlas.GeoClue : Object {
+    private GClue.Simple? simple;
 
     public GeoClue () {
-        country_code = null;
-        minimal_distance = 1000.0d;
     }
 
-    public async void seek () {
-        try {
-            simple = yield new GClue.Simple (DESKTOP_ID, GClue.AccuracyLevel.EXACT, null);
-        } catch (Error e) {
-            warning ("Failed to connect to GeoClue2 service: %s", e.message);
-            return;
+    public async GClue.Location? get_location () {
+        if (simple == null) {
+            try {
+                simple = yield new GClue.Simple (Build.PROJECT_NAME, GClue.AccuracyLevel.EXACT, null);
+            } catch (Error e) {
+                warning ("Failed to connect to GeoClue2 service: %s", e.message);
+                return null;
+            }
         }
 
-        simple.notify["location"].connect (() => {
-            on_location_updated.begin ();
-        });
-
-        on_location_updated.begin ();
-    }
-
-    public async void on_location_updated () {
-        geo_location = simple.get_location ();
+        return simple.get_location ();
     }
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -42,6 +42,10 @@ public class Atlas.MainWindow : Gtk.ApplicationWindow {
         user_location.image = new Gtk.Image.from_icon_name ("mark-location-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
         user_location.tooltip_text = _("Current Location");
 
+        var spinner = new Gtk.Spinner ();
+        spinner.tooltip_text = _("Detecting your location…");
+        spinner.no_show_all = true;
+
         search = new Gtk.SearchEntry ();
         search.placeholder_text = _("Search Location");
         search.valign = Gtk.Align.CENTER;
@@ -55,6 +59,7 @@ public class Atlas.MainWindow : Gtk.ApplicationWindow {
         headerbar.pack_start (user_location);
         headerbar.pack_end (button_search_options);
         headerbar.pack_end (search);
+        headerbar.pack_end (spinner);
         headerbar.title = _("Atlas");
 
         set_titlebar (headerbar);
@@ -93,13 +98,21 @@ public class Atlas.MainWindow : Gtk.ApplicationWindow {
         geo_clue = new Atlas.GeoClue ();
 
         user_location.clicked.connect (() => {
-            view.center_on (geo_clue.geo_location.latitude, geo_clue.geo_location.longitude);
-            view.zoom_level = 12;
+            user_location.sensitive = false;
+            spinner.show ();
+            spinner.start ();
+
+            geo_clue.get_location.begin ((obj, res) => {
+                var location = geo_clue.get_location.end (res);
+                view.center_on (location.latitude, location.longitude);
+                view.zoom_level = 15;
+                spinner.hide ();
+                spinner.stop ();
+                user_location.sensitive = true;
+            });
         });
 
         button_search_options.clicked.connect (on_search_options_clicked);
-
-        geo_clue.seek.begin ();
     }
 
     protected override bool configure_event (Gdk.EventConfigure event) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -20,7 +20,6 @@
 public class Atlas.MainWindow : Gtk.ApplicationWindow {
     private GtkChamplain.Embed champlain;
     private Gtk.SearchEntry search;
-    private Gtk.Button user_location;
     private GLib.Cancellable search_cancellable;
     private Gtk.EntryCompletion location_completion;
     private Gtk.ToggleButton button_search_options;
@@ -38,12 +37,12 @@ public class Atlas.MainWindow : Gtk.ApplicationWindow {
     }
 
     construct {
-        user_location = new Gtk.Button ();
-        user_location.image = new Gtk.Image.from_icon_name ("mark-location-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
-        user_location.tooltip_text = _("Current Location");
+        var current_location = new Gtk.Button ();
+        current_location.image = new Gtk.Image.from_icon_name ("mark-location-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+        current_location.tooltip_text = _("Current Location");
 
         var spinner = new Gtk.Spinner ();
-        spinner.tooltip_text = _("Detecting your location…");
+        spinner.tooltip_text = _("Detecting your current location…");
         spinner.no_show_all = true;
 
         search = new Gtk.SearchEntry ();
@@ -56,7 +55,7 @@ public class Atlas.MainWindow : Gtk.ApplicationWindow {
 
         var headerbar = new Gtk.HeaderBar ();
         headerbar.show_close_button = true;
-        headerbar.pack_start (user_location);
+        headerbar.pack_start (current_location);
         headerbar.pack_end (button_search_options);
         headerbar.pack_end (search);
         headerbar.pack_end (spinner);
@@ -97,18 +96,18 @@ public class Atlas.MainWindow : Gtk.ApplicationWindow {
 
         geo_clue = new Atlas.GeoClue ();
 
-        user_location.clicked.connect (() => {
-            user_location.sensitive = false;
+        current_location.clicked.connect (() => {
+            current_location.sensitive = false;
             spinner.show ();
             spinner.start ();
 
-            geo_clue.get_location.begin ((obj, res) => {
-                var location = geo_clue.get_location.end (res);
+            geo_clue.get_current_location.begin ((obj, res) => {
+                var location = geo_clue.get_current_location.end (res);
                 view.center_on (location.latitude, location.longitude);
                 view.zoom_level = 15;
                 spinner.hide ();
                 spinner.stop ();
-                user_location.sensitive = true;
+                current_location.sensitive = true;
             });
         });
 


### PR DESCRIPTION
Clicking the location button as soon as you launch the app, you get the following message:

```
(com.github.ryonakano.atlas:2): GLib-GObject-CRITICAL **: 20:23:05.273: g_object_get: assertion 'G_IS_OBJECT (object)' failed

(com.github.ryonakano.atlas:2): GLib-GObject-CRITICAL **: 20:23:05.273: g_object_get: assertion 'G_IS_OBJECT (object)' failed
```

This is because `geo_location` property in `GeoClue` Object is not yet initialized because of the async method.

This PR fixes that issue and plus show the spinner while the app getting your location:

![Screenshot from 2021-11-18 20-25-41](https://user-images.githubusercontent.com/26003928/142406905-7397a78c-21f8-462d-9532-9b10f2ef5223.png)
