### PR TITLE
fix: metainfo: Correct project license

### DIFF
--- a/data/atlas.metainfo.xml.in.in
+++ b/data/atlas.metainfo.xml.in.in
@@ -5,7 +5,7 @@
   <launchable type="desktop-id">@APP_ID@.desktop</launchable>
   <translation type="gettext">@GETTEXT_PACKAGE@</translation>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-3.0</project_license>
+  <project_license>GPL-3.0-or-later</project_license>
 
   <name translate="no">Atlas</name>
   <summary>View where to go</summary>


### PR DESCRIPTION
This project is licensed under GPL 3.0 or later, as written in the each source file.