### PR TITLE
Flatpak: Use id instead of deprecated app-id

### DIFF
--- a/build-aux/appcenter/com.github.ryonakano.atlas.Devel.yml
+++ b/build-aux/appcenter/com.github.ryonakano.atlas.Devel.yml
@@ -1,4 +1,4 @@
-app-id: com.github.ryonakano.atlas.Devel
+id: com.github.ryonakano.atlas.Devel
 runtime: io.elementary.Platform
 runtime-version: '8'
 sdk: io.elementary.Sdk

--- a/com.github.ryonakano.atlas.yml
+++ b/com.github.ryonakano.atlas.yml
@@ -1,4 +1,4 @@
-app-id: com.github.ryonakano.atlas
+id: com.github.ryonakano.atlas
 runtime: io.elementary.Platform
 runtime-version: '8'
 sdk: io.elementary.Sdk


### PR DESCRIPTION
From https://docs.flatpak.org/en/latest/flatpak-builder-command-reference.html:

> Note, "app-id" is deprecated and preserved only for backwards compatibility.