### PR TITLE
MainWindow: Use search convention from GNOME

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -55,8 +55,9 @@ public class Atlas.MainWindow : Adw.ApplicationWindow {
         };
 
         var search_placeholder = new Adw.StatusPage () {
-            title = _("No Search Results"),
-            description = _("Try changing the search term."),
+            title = _("No Results Found"),
+            description = _("Try a different search"),
+            icon_name = "edit-find-symbolic",
             margin_start = 12,
             margin_end = 12
         };


### PR DESCRIPTION
Follow the convention often seen in GNOME:

![image](https://github.com/user-attachments/assets/c7e94bc4-e095-400c-a0af-3981825135e4)
