### PR TITLE
Flatpak: Use git for modules

### DIFF
--- a/build-aux/appcenter/com.github.ryonakano.atlas.Devel.yml
+++ b/build-aux/appcenter/com.github.ryonakano.atlas.Devel.yml
@@ -42,13 +42,13 @@ modules:
         config-opts:
           - --disable-protoc
         sources:
-          - type: archive
-            url: https://github.com/protobuf-c/protobuf-c/releases/download/v1.5.2/protobuf-c-1.5.2.tar.gz
-            sha256: e2c86271873a79c92b58fef7ebf8de1aa0df4738347a8bd5d4e65a80a16d0d24
+          - type: git
+            url: https://github.com/protobuf-c/protobuf-c.git
+            tag: v1.5.2
+            commit: 4719fdd7760624388c2c5b9d6759eb6a47490626
             x-checker-data:
-              type: anitya
-              project-id: 3716
-              url-template: https://github.com/protobuf-c/protobuf-c/releases/download/v$version/protobuf-c-$version.tar.gz
+              type: git
+              tag-pattern: '^v([\d.]+)$'
 
   - name: atlas
     buildsystem: meson

--- a/build-aux/flathub/com.github.ryonakano.atlas.Devel.yml
+++ b/build-aux/flathub/com.github.ryonakano.atlas.Devel.yml
@@ -40,13 +40,13 @@ modules:
         config-opts:
           - --disable-protoc
         sources:
-          - type: archive
-            url: https://github.com/protobuf-c/protobuf-c/releases/download/v1.5.2/protobuf-c-1.5.2.tar.gz
-            sha256: e2c86271873a79c92b58fef7ebf8de1aa0df4738347a8bd5d4e65a80a16d0d24
+          - type: git
+            url: https://github.com/protobuf-c/protobuf-c.git
+            tag: v1.5.2
+            commit: 4719fdd7760624388c2c5b9d6759eb6a47490626
             x-checker-data:
-              type: anitya
-              project-id: 3716
-              url-template: https://github.com/protobuf-c/protobuf-c/releases/download/v$version/protobuf-c-$version.tar.gz
+              type: git
+              tag-pattern: '^v([\d.]+)$'
 
   - name: atlas
     buildsystem: meson

--- a/com.github.ryonakano.atlas.yml
+++ b/com.github.ryonakano.atlas.yml
@@ -42,13 +42,13 @@ modules:
         config-opts:
           - --disable-protoc
         sources:
-          - type: archive
-            url: https://github.com/protobuf-c/protobuf-c/releases/download/v1.5.2/protobuf-c-1.5.2.tar.gz
-            sha256: e2c86271873a79c92b58fef7ebf8de1aa0df4738347a8bd5d4e65a80a16d0d24
+          - type: git
+            url: https://github.com/protobuf-c/protobuf-c.git
+            tag: v1.5.2
+            commit: 4719fdd7760624388c2c5b9d6759eb6a47490626
             x-checker-data:
-              type: anitya
-              project-id: 3716
-              url-template: https://github.com/protobuf-c/protobuf-c/releases/download/v$version/protobuf-c-$version.tar.gz
+              type: git
+              tag-pattern: '^v([\d.]+)$'
 
   - name: atlas
     buildsystem: meson


### PR DESCRIPTION
I prefer archives for quick download but that should be a tiny difference in the modern fast networks. So we can use the simple git pattern for Flatpak External Data Checker