### PR TITLE
Metainfo: add environment info to screenshots

### DIFF
--- a/data/atlas.metainfo.xml.in.in
+++ b/data/atlas.metainfo.xml.in.in
@@ -24,12 +24,12 @@
   </description>
 
   <screenshots>
-    <screenshot type="default">
-      <caption>App window in the light mode</caption>
+    <screenshot type="default" environment="pantheon">
+      <caption>See locations on a map</caption>
       <image>https://raw.githubusercontent.com/ryonakano/atlas/@VERSION@/data/screenshots/screenshot-light.png</image>
     </screenshot>
-    <screenshot>
-      <caption>App window in the dark mode</caption>
+    <screenshot environment="pantheon:dark">
+      <caption>See locations on a map</caption>
       <image>https://raw.githubusercontent.com/ryonakano/atlas/@VERSION@/data/screenshots/screenshot-dark.png</image>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
Set the environment tag so screenshots automatically show in dark and light mode. Update the caption since they'll only be shown in dark or light mode