### PR TITLE
MainWindow: search popover use propagate_natural_height

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -88,12 +88,11 @@ public class Atlas.MainWindow : Adw.ApplicationWindow {
         var search_res_list_scrolled = new Gtk.ScrolledWindow () {
             child = search_res_list,
             hscrollbar_policy = Gtk.PolicyType.NEVER,
-            vexpand = true
+            propagate_natural_height = true
         };
 
         search_res_popover = new Gtk.Popover () {
             width_request = 400,
-            height_request = 500,
             has_arrow = false,
             child = search_res_list_scrolled,
             default_widget = search_res_list

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -88,6 +88,7 @@ public class Atlas.MainWindow : Adw.ApplicationWindow {
         var search_res_list_scrolled = new Gtk.ScrolledWindow () {
             child = search_res_list,
             hscrollbar_policy = Gtk.PolicyType.NEVER,
+            max_content_height = 500,
             propagate_natural_height = true
         };
 


### PR DESCRIPTION
Use propagate natural height and max content height instead of hardcoding popover height:

![Screenshot from 2025-07-08 20 02 53](https://github.com/user-attachments/assets/9d4fabd3-9f7d-4bee-ad15-8bbeb4f9f0ec)

![Screenshot from 2025-07-08 20 00 15](https://github.com/user-attachments/assets/1f5ebe70-86a9-4a34-ada7-8e47695b88b8)
