### PR TITLE
Fix some build warnings

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -184,6 +184,7 @@ public class Atlas.MainWindow : Adw.ApplicationWindow {
         var search_entry_gesture = new Gtk.EventControllerKey ();
         search_entry_gesture.key_pressed.connect (() => {
             search_res_popover.popdown ();
+            return true;
         });
         ((Gtk.Widget) search_res_popover).add_controller (search_entry_gesture);
 
@@ -242,8 +243,8 @@ public class Atlas.MainWindow : Adw.ApplicationWindow {
                                          Util.map_source_action_transform_to_cb,
                                          Util.map_source_action_transform_from_cb);
         Application.settings.bind_with_mapping ("map-source", map_widget, "map-source", SettingsBindFlags.DEFAULT,
-                                                Util.map_source_get_mapping_cb,
-                                                Util.map_source_set_mapping_cb,
+                                                (SettingsBindGetMappingShared) Util.map_source_get_mapping_cb,
+                                                (SettingsBindSetMappingShared) Util.map_source_set_mapping_cb,
                                                 null, null);
         add_action (map_source_action);
     }


### PR DESCRIPTION
Fixes the following two warnings:

```
MainWindow.c: In function ‘_atlas_main_window___lambda10_’:
MainWindow.c:1643:1: warning: no return statement in function returning non-void [-Wreturn-type]
```

```
../src/MainWindow.vala: In function ‘atlas_main_window_setup_map_source_action’:
../src/MainWindow.vala:244:172: warning: passing argument 7 of ‘g_settings_bind_with_mapping’ from incompatible pointer type [-Wincompatible-pointer-types]
  244 |         Application.settings.bind_with_mapping ("map-source", map_widget, "map-source", SettingsBindFlags.DEFAULT,
      |                                                                                                                                                                            ^                                                         
      |                                                                                                                                                                            |
      |                                                                                                                                                                            GVariant * (*)(GValue *, const GVariantType *, void *) {aka struct _GVariant * (*)(struct _GValue *, const struct _GVariantType *, void *)}
In file included from /usr/include/glib-2.0/gio/gio.h:137,
                 from /usr/include/gtk-4.0/gtk/css/gtkcsssection.h:24,
                 from /usr/include/gtk-4.0/gtk/css/gtkcss.h:36,
                 from /usr/include/gtk-4.0/gtk/gtk.h:29,
                 from /usr/include/libadwaita-1/adwaita.h:9,
                 from src/com.github.ryonakano.atlas.p/MainWindow.c:10:
/usr/include/glib-2.0/gio/gsettings.h:326:99: note: expected ‘GSettingsBindSetMapping’ {aka ‘struct _GVariant * (*)(const struct _GValue *, const struct _GVariantType *, void *)’} but argument is of type ‘GVariant * (*)(GValue *, const GVariantType *, void *)’ {aka ‘struct _GVariant * (*)(struct _GValue *, const struct _GVariantType *, void *)’}
  326 |                                                                          GSettingsBindSetMapping  set_mapping,
      |                                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
```