### PR TITLE
Data: add missing rename to install gschema

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -27,7 +27,8 @@ i18n.merge_file(
 
 install_data(
     'maps.gschema.xml',
-    install_dir: get_option('datadir') / 'glib-2.0' / 'schemas'
+    install_dir: get_option('datadir') / 'glib-2.0' / 'schemas',
+    rename: meson.project_name() + '.gschema.xml'
 )
 
 asresources = gnome.compile_resources(


### PR DESCRIPTION
Missed this when reviewing the rename branch somehow