### PR TITLE
Desktop: add missing keys, set spec version

### DIFF
--- a/data/maps.desktop.in
+++ b/data/maps.desktop.in
@@ -1,10 +1,14 @@
 [Desktop Entry]
-Name=Maps
-GenericName=Map
-Comment=View where to go
-Categories=GTK;Utility;Science;Maps;
-Exec=io.elementary.maps
-Icon=io.elementary.maps
+Version=1.5
 Type=Application
+
+Name=Maps
+Comment=View where to go
+Categories=GTK;Utility;Science;Maps
+Keywords=trip;explore;
+
+Icon=io.elementary.maps
+Exec=io.elementary.maps
+SingleMainWindow=true
+StartupNotify=true
 Terminal=false
-Keywords=Trip;Explore;


### PR DESCRIPTION
* Organize like we have in other elementary apps
* Add Desktop entry spec version
* Remove unused `GenericName`. The main app name is already generic
* Add `SingleMainWindow` and `StartupNotify` keys