### PR TITLE
SearchResultItem: provide better description labels

### DIFF
--- a/src/SearchResultItem.vala
+++ b/src/SearchResultItem.vala
@@ -15,13 +15,22 @@ public class Maps.SearchResultItem : Granite.Bin {
         set {
             _place = value;
 
-            var street = place.street ?? unknown_text;
-            var postal_code = place.postal_code ?? unknown_text;
-            var town = place.town ?? unknown_text;
-
             image.gicon = place.icon;
             name_label.label = place.name;
-            info_label.label = "%s, %s, %s".printf (street, postal_code, town);
+
+            if (place.place_type == TOWN && place.state != null && place.country != null) {
+                ///TRANSLATORS: a state or probince, followed by a country
+                info_label.label = _("%s, %s").printf (place.state, place.country);
+            } else if (place.street_address != null && place.town != null) {
+                ///TRANSLATORS: a street address, followed by a town or city
+                info_label.label = _("%s, %s").printf (place.street_address, place.town);
+            } else {
+                var street = place.street ?? unknown_text;
+                var postal_code = place.postal_code ?? unknown_text;
+                var town = place.town ?? unknown_text;
+
+                info_label.label = "%s, %s, %s, %s".printf (street, postal_code, town, place.state);
+            }
         }
     }
 

--- a/src/SearchResultItem.vala
+++ b/src/SearchResultItem.vala
@@ -18,19 +18,25 @@ public class Maps.SearchResultItem : Granite.Bin {
             image.gicon = place.icon;
             name_label.label = place.name;
 
+            if (place.street_address != null && place.town != null) {
+                ///TRANSLATORS: a street address, followed by a town or city
+                info_label.label = _("%s, %s").printf (place.street_address, place.town);
+
+                return;
+            }
+
             if (place.place_type == TOWN && place.state != null && place.country != null) {
                 ///TRANSLATORS: a state or probince, followed by a country
                 info_label.label = _("%s, %s").printf (place.state, place.country);
-            } else if (place.street_address != null && place.town != null) {
-                ///TRANSLATORS: a street address, followed by a town or city
-                info_label.label = _("%s, %s").printf (place.street_address, place.town);
-            } else {
-                var street = place.street ?? unknown_text;
-                var postal_code = place.postal_code ?? unknown_text;
-                var town = place.town ?? unknown_text;
 
-                info_label.label = "%s, %s, %s, %s".printf (street, postal_code, town, place.state);
+                return;
             }
+
+            var street = place.street ?? unknown_text;
+            var postal_code = place.postal_code ?? unknown_text;
+            var town = place.town ?? unknown_text;
+
+            info_label.label = "%s, %s, %s, %s".printf (street, postal_code, town, place.state);
         }
     }
 


### PR DESCRIPTION
Trying to make better descriptions. Some problems:
* If I'm looking up a bar, restaurant, point of interest, etc I probably want an address. Some of these things don't have an address though, so we need a way to fall back to more broad information. So we can't just use a case statement based on place type
* Towns/Cities don't have `street` info. They need something way less granular
* Something like the "Pacific Ocean", what do you even write for this?
* It doesn't appear we have continent information so no idea what to write about countries
* Do we need to localize delimiters individually? In English I think a comma is pretty much okay across the board. But what about other locales?

Todo:
- [ ] Probably make this a function of its own