### PR TITLE
Add elementary, Inc. to the copyright headers

### DIFF
--- a/data/maps.metainfo.xml.in
+++ b/data/maps.metainfo.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2014-2015 Atlas Developers, 2018-2025 Ryo Nakano -->
+<!-- Copyright 2025 elementary, Inc., 2018-2025 Ryo Nakano, 2014-2015 Atlas Developers -->
 <component type="desktop-application">
   <id>io.elementary.maps</id>
   <launchable type="desktop-id">io.elementary.maps.desktop</launchable>

--- a/po/de.po
+++ b/po/de.po
@@ -1,6 +1,7 @@
 # German translations for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # J. Lavoie <j.lavoie@net-c.ca>, 2022.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2024.

--- a/po/es.po
+++ b/po/es.po
@@ -1,6 +1,7 @@
 # Spanish translations for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # gallegonovato <fran-carro@hotmail.es>, 2023, 2024.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2024.

--- a/po/et.po
+++ b/po/et.po
@@ -1,6 +1,7 @@
 # Estonian translations for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # Priit Jõerüüt <hwlate@joeruut.com>, 2024, 2025.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2024.

--- a/po/extra/de.po
+++ b/po/extra/de.po
@@ -1,6 +1,7 @@
 # German translations for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # J. Lavoie <j.lavoie@net-c.ca>, 2022.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2024.

--- a/po/extra/es.po
+++ b/po/extra/es.po
@@ -1,6 +1,7 @@
 # Spanish translations for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # gallegonovato <fran-carro@hotmail.es>, 2023, 2024.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2024.

--- a/po/extra/et.po
+++ b/po/extra/et.po
@@ -1,6 +1,7 @@
 # Estonian translations for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # Priit Jõerüüt <hwlate@joeruut.com>, 2024, 2025.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2024.

--- a/po/extra/fi.po
+++ b/po/extra/fi.po
@@ -1,6 +1,7 @@
 # Finnish translations for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # Jiri Grönroos <jiri.gronroos@iki.fi>, 2023.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2024.

--- a/po/extra/fr.po
+++ b/po/extra/fr.po
@@ -1,6 +1,7 @@
 # French translations for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # Nathan Bonnemains (@NathanBnm), 2021.
 # J. Lavoie <j.lavoie@net-c.ca>, 2022.

--- a/po/extra/hi.po
+++ b/po/extra/hi.po
@@ -1,6 +1,7 @@
 # Hindi translations for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # Scrambled777 <weblate.scrambled777@simplelogin.com>, 2024.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2024.

--- a/po/extra/it.po
+++ b/po/extra/it.po
@@ -1,6 +1,7 @@
 # Italian translations for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # albanobattistella <albano_battistella@hotmail.com>, 2021, 2022, 2023, 2024, 2025.
 # J. Lavoie <j.lavoie@net-c.ca>, 2022.

--- a/po/extra/ja.po
+++ b/po/extra/ja.po
@@ -1,6 +1,7 @@
 # Japanese translations for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # Ryo Nakano <ryonakaknock3@gmail.com>, 2021, 2022, 2023, 2024, 2025.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2024.

--- a/po/extra/lt.po
+++ b/po/extra/lt.po
@@ -1,6 +1,7 @@
 # Lithuanian translation for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # PolPolyLingo <paulius.narkevicius@vilniustech.lt>, 2023
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2024.

--- a/po/extra/nb_NO.po
+++ b/po/extra/nb_NO.po
@@ -1,6 +1,7 @@
 # Norwegian Bokmål translations for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # Allan Nordhøy <epost@anotheragency.no>, 2024.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2024.

--- a/po/extra/nl.po
+++ b/po/extra/nl.po
@@ -1,6 +1,7 @@
 # Dutch translations for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # Heimen Stoffels <vistausss@fastmail.com>, 2022, 2023.
 # Philip Goto <philip.goto@gmail.com>, 2023.

--- a/po/extra/pl.po
+++ b/po/extra/pl.po
@@ -1,6 +1,7 @@
 # Polish translation for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # PolPolyLingo <paulius.narkevicius@vilniustech.lt>, 2023
 # Eryk Michalak <gnu.ewm@protonmail.com>, 2023.

--- a/po/extra/pt.po
+++ b/po/extra/pt.po
@@ -1,6 +1,7 @@
 # Portuguese translations for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # Hugo Carvalho <hugokarvalho@hotmail.com>, 2022.
 # Felipe Nogueira <contato.fnog@gmail.com>, 2023.

--- a/po/extra/pt_BR.po
+++ b/po/extra/pt_BR.po
@@ -1,6 +1,7 @@
 # Portuguese (Brazil) translations for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # John Peter Sa <johnppetersa@gmail.com>, 2025.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2025.

--- a/po/extra/ru.po
+++ b/po/extra/ru.po
@@ -1,6 +1,7 @@
 # Russian translations for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # lenemter <lenemter@gmail.com>, 2022, 2023, 2024.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2024.

--- a/po/extra/sk.po
+++ b/po/extra/sk.po
@@ -1,6 +1,7 @@
 # Slovak translations for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # Ryo Nakano <ryonakaknock3@gmail.com>, 2022.
 # JohnDumpling <john_dumpling@protonmail.com>, 2022, 2023.

--- a/po/extra/ta.po
+++ b/po/extra/ta.po
@@ -1,6 +1,7 @@
 # Tamil translations for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # தமிழ்நேரம் <anishprabu.t@gmail.com>, 2025.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2025.

--- a/po/extra/tr.po
+++ b/po/extra/tr.po
@@ -1,6 +1,7 @@
 # Turkish translations for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # Oğuz Ersen <oguz@ersen.moe>, 2022, 2023.
 # Sabri Ünal <libreajans@gmail.com>, 2023.

--- a/po/extra/uk.po
+++ b/po/extra/uk.po
@@ -1,6 +1,7 @@
 # Ukrainian translations for extra package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the extra package.
 # Ihor Hordiichuk <igor_ck@outlook.com>, 2022, 2023, 2024, 2025.
 # Artem <artem@molotov.work>, 2022.

--- a/po/fi.po
+++ b/po/fi.po
@@ -1,6 +1,7 @@
 # Finnish translations for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # Jiri Grönroos <jiri.gronroos@iki.fi>, 2023.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2024.

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,6 +1,7 @@
 # French translations for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # Nathan Bonnemains (@NathanBnm), 2021.
 # J. Lavoie <j.lavoie@net-c.ca>, 2022.

--- a/po/hi.po
+++ b/po/hi.po
@@ -1,6 +1,7 @@
 # Hindi translations for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # Scrambled777 <weblate.scrambled777@simplelogin.com>, 2024.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2024.

--- a/po/it.po
+++ b/po/it.po
@@ -1,6 +1,7 @@
 # Italian translations for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # albanobattistella <albano_battistella@hotmail.com>, 2021, 2022, 2023, 2024, 2025.
 # J. Lavoie <j.lavoie@net-c.ca>, 2022.

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,6 +1,7 @@
 # Japanese translations for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # Ryo Nakano <ryonakaknock3@gmail.com>, 2021, 2022, 2023, 2024, 2025.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2024.

--- a/po/lt.po
+++ b/po/lt.po
@@ -1,6 +1,7 @@
 # Lithuanian translation for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # PolPolyLingo <paulius.narkevicius@vilniustech.lt>, 2023
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2024.

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -1,6 +1,7 @@
 # Norwegian Bokmål translations for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # Allan Nordhøy <epost@anotheragency.no>, 2024.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2024.

--- a/po/nl.po
+++ b/po/nl.po
@@ -1,6 +1,7 @@
 # Dutch translations for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # Heimen Stoffels <vistausss@fastmail.com>, 2022, 2023.
 # Philip Goto <philip.goto@gmail.com>, 2023.

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,6 +1,7 @@
 # Polish translation for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # PolPolyLingo <paulius.narkevicius@vilniustech.lt>, 2023
 # Eryk Michalak <gnu.ewm@protonmail.com>, 2023.

--- a/po/pt.po
+++ b/po/pt.po
@@ -1,6 +1,7 @@
 # Portuguese translations for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # Hugo Carvalho <hugokarvalho@hotmail.com>, 2022.
 # Felipe Nogueira <contato.fnog@gmail.com>, 2023.

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,6 +1,7 @@
 # Portuguese (Brazil) translations for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # John Peter Sa <johnppetersa@gmail.com>, 2025.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2025.

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,6 +1,7 @@
 # Russian translations for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # lenemter <lenemter@gmail.com>, 2022, 2023, 2024.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2024.

--- a/po/sk.po
+++ b/po/sk.po
@@ -1,6 +1,7 @@
 # Slovak translations for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # Ryo Nakano <ryonakaknock3@gmail.com>, 2022.
 # JohnDumpling <john_dumpling@protonmail.com>, 2022, 2023.

--- a/po/ta.po
+++ b/po/ta.po
@@ -1,6 +1,7 @@
 # Tamil translations for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # தமிழ்நேரம் <anishprabu.t@gmail.com>, 2025.
 # Fill read-only add-on <noreply-addon-fill@weblate.org>, 2025.

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,6 +1,7 @@
 # Turkish translations for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # Oğuz Ersen <oguz@ersen.moe>, 2022, 2023.
 # Sabri Ünal <libreajans@gmail.com>, 2023.

--- a/po/uk.po
+++ b/po/uk.po
@@ -1,6 +1,7 @@
 # Ukrainian translations for io.elementary.maps package.
-# Copyright (C) 2014-2015 Atlas Developers
+# Copyright (C) 2025 elementary, Inc.
 # Copyright (C) 2018-2025 Ryo Nakano
+# Copyright (C) 2014-2015 Atlas Developers
 # This file is distributed under the same license as the io.elementary.maps package.
 # Ihor Hordiichuk <igor_ck@outlook.com>, 2022, 2023, 2024, 2025.
 # Artem <artem@molotov.work>, 2022.

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -1,7 +1,8 @@
 /*
  * SPDX-License-Identifier: GPL-3.0-or-later
- * SPDX-FileCopyrightText: 2014-2015 Atlas Developers
+ * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
  *                         2018-2025 Ryo Nakano <ryonakaknock3@gmail.com>
+ *                         2014-2015 Atlas Developers
  */
 
 public class Maps.Application : Adw.Application {

--- a/src/Define.vala
+++ b/src/Define.vala
@@ -1,6 +1,7 @@
 /*
  * SPDX-License-Identifier: GPL-3.0-or-later
- * SPDX-FileCopyrightText: 2018-2025 Ryo Nakano <ryonakaknock3@gmail.com>
+ * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
+ *                         2018-2025 Ryo Nakano <ryonakaknock3@gmail.com>
  */
 
 namespace Define {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1,7 +1,8 @@
 /*
  * SPDX-License-Identifier: GPL-3.0-or-later
- * SPDX-FileCopyrightText: 2014-2015 Atlas Developers
+ * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
  *                         2018-2025 Ryo Nakano <ryonakaknock3@gmail.com>
+ *                         2014-2015 Atlas Developers
  */
 
 public class Maps.MainWindow : Adw.ApplicationWindow {

--- a/src/MapWidget.vala
+++ b/src/MapWidget.vala
@@ -1,7 +1,8 @@
 /*
  * SPDX-License-Identifier: GPL-3.0-or-later
- * SPDX-FileCopyrightText: 2014-2015 Atlas Developers
+ * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
  *                         2018-2025 Ryo Nakano <ryonakaknock3@gmail.com>
+ *                         2014-2015 Atlas Developers
  */
 
 public class Maps.MapWidget : Gtk.Box {

--- a/src/Util.vala
+++ b/src/Util.vala
@@ -1,6 +1,7 @@
 /*
  * SPDX-License-Identifier: GPL-3.0-or-later
- * SPDX-FileCopyrightText: 2018-2025 Ryo Nakano <ryonakaknock3@gmail.com>
+ * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
+ *                         2018-2025 Ryo Nakano <ryonakaknock3@gmail.com>
  */
 
 namespace Util {


### PR DESCRIPTION
Part of #110
Also unify the order of copyright holders from newer to older.
