### PR TITLE
MainWindow: don't set spinner visibility

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -193,7 +193,6 @@ public class Maps.MainWindow : Adw.ApplicationWindow {
     private void busy_start (BusyReason new_reason) {
         // Not busy → Busy
         if (!(bool)(current_busy_reason & BusyReason.ANY)) {
-            spinner.visible = true;
             spinner.spinning = true;
         }
 
@@ -215,7 +214,6 @@ public class Maps.MainWindow : Adw.ApplicationWindow {
 
         // Busy → Not busy
         if (!(bool)(current_busy_reason & BusyReason.ANY)) {
-            spinner.visible = false;
             spinner.spinning = false;
         }
     }


### PR DESCRIPTION
Don't mess with spinner visiblity. It already does the right thing to hide or show. This prevents some jank with search entry and results changing position as you type