### PR TITLE
Styles: add button.osd styles

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -19,3 +19,30 @@ map-point {
         transform: scale(1);
     }
 }
+
+button.osd {
+    background: @bg_color;
+    box-shadow:
+        inset 0 -1px 0 0 rgba(255, 255, 255, 0.2),
+        inset 0 1px 0 0 rgba(255, 255, 255, 0.3),
+        inset 1px 0 0 0 rgba(255, 255, 255, 0.07),
+        inset -1px 0 0 0 rgba(255, 255, 255, 0.07),
+        0 0 0 1px rgba(0, 0, 0, 0.1),
+        0 3px 4px rgba(0, 0, 0, 0.15),
+        0 3px 3px -3px rgba(0, 0, 0, 0.35);
+    color: @text_color;
+    min-height: 2em;
+    min-width: 2em;
+}
+
+button.osd:active {
+    background: @insensitive_bg_color;
+}
+
+.linked.vertical button.osd:first-child {
+    margin-bottom: 0;
+}
+
+.linked.vertical button.osd:not(:first-child) {
+    margin-top: 0;
+}

--- a/data/Application.css
+++ b/data/Application.css
@@ -20,6 +20,7 @@ map-point {
     }
 }
 
+/* TODO Remove when https://github.com/elementary/granite/issues/897 is fixed */
 button.osd {
     background: @bg_color;
     box-shadow:


### PR DESCRIPTION
There's some fixes for .osd styles coming in newer Granite, but this is going to be a huge API break for the stylesheet so I don't know when it will land. Until then, we can carry our own styles:

<img width="1054" height="845" alt="Screenshot from 2025-07-15 14 25 21" src="https://github.com/user-attachments/assets/7fac7605-1d47-4d56-a4fc-8b7d4baa28ba" />
